### PR TITLE
Timestamp Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ This will modify the document to look something like this:
 
 The timestamp is in UTC.
 
+To change the format of the timestamp set a `MONGODB_TIMESTAMP_KEY` string value:
+
+    MONGODB_TIMESTAMP_KEY = 'created'
+
+Will modify the document timestamp to look like this:
+
+    {
+        ...
+        'created': ISODate("2013-01-10T07:43:56.797Z"),
+        ...
+    }
+
 Full list of config options
 ---------------------------
 Configuration options available. Put these in your `settings.py` file.
@@ -123,6 +135,15 @@ Configuration options available. Put these in your `settings.py` file.
         <td>
             If this is set to True, scrapy-mongodb will add a timestamp key to the documents. The document will look like this:<br />
             { scrapy_mongo: { ts: ISODate("2013-01-10T07:43:56.797Z") } }
+        </td>
+    </tr>
+    <tr>
+        <td>MONGODB_TIMESTAMP_KEY</td>
+        <td>None</td>
+        <td>No</td>
+        <td>
+            If this is set to a string, scrapy-mongodb will use this to change the key used for the timestamp. Example: `created` would look like:<br />
+            {'created' ISODate("2013-01-10T07:43:56.797Z") }
         </td>
     </tr>
     <tr>

--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -56,7 +56,7 @@ class MongoDBPipeline():
         'unique_key': None,
         'buffer': None,
         'append_timestamp': False,
-        'timestamp_key': False,
+        'timestamp_key': None,
         'stop_on_duplicate': 0,
     }
 
@@ -206,7 +206,7 @@ class MongoDBPipeline():
             item = dict(item)
 
             if self.config['append_timestamp']:
-                if self.config['timestamp_key']:
+                if not not_set(self.config['timestamp_key']):
                     item[self.config['timestamp_key']] = datetime.datetime.utcnow()
                 else:
                     item['scrapy-mongodb'] = {'ts': datetime.datetime.utcnow()}
@@ -245,7 +245,10 @@ class MongoDBPipeline():
             item = dict(item)
 
             if self.config['append_timestamp']:
-                item['scrapy-mongodb'] = {'ts': datetime.datetime.utcnow()}
+                if not not_set(self.config['timestamp_key']):
+                    item[self.config['timestamp_key']] = datetime.datetime.utcnow()
+                else:
+                    item['scrapy-mongodb'] = {'ts': datetime.datetime.utcnow()}
 
         if self.config['unique_key'] is None:
             try:

--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -56,6 +56,7 @@ class MongoDBPipeline():
         'unique_key': None,
         'buffer': None,
         'append_timestamp': False,
+        'timestamp_key': False,
         'stop_on_duplicate': 0,
     }
 
@@ -169,6 +170,7 @@ class MongoDBPipeline():
             ('unique_key', 'MONGODB_UNIQUE_KEY'),
             ('buffer', 'MONGODB_BUFFER_DATA'),
             ('append_timestamp', 'MONGODB_ADD_TIMESTAMP'),
+            ('timestamp_key', 'MONGODB_TIMESTAMP_KEY'),
             ('stop_on_duplicate', 'MONGODB_STOP_ON_DUPLICATE')
         ]
 
@@ -204,7 +206,10 @@ class MongoDBPipeline():
             item = dict(item)
 
             if self.config['append_timestamp']:
-                item['scrapy-mongodb'] = {'ts': datetime.datetime.utcnow()}
+                if self.config['timestamp_key']:
+                    item[self.config['timestamp_key']] = datetime.datetime.utcnow()
+                else:
+                    item['scrapy-mongodb'] = {'ts': datetime.datetime.utcnow()}
 
             self.item_buffer.append(item)
 


### PR DESCRIPTION
Adding a `MONGODB_TIMESTAMP_KEY` option to override the default behaviour of `MONGODB_ADD_TIMESTAMP`. 

E.g. With a setting of `MONGODB_TIMESTAMP_KEY = "created"` would add the following to item:

```
{
    ...
    'created': ISODate("2013-01-10T07:43:56.797Z"),
    ...
}
```

Only works if `MONGODB_ADD_TIMESTAMP` is set. 
