### PR TITLE
Fix for unicodeerror in line 102

### DIFF
--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -99,7 +99,7 @@ class MongoDBPipeline(BaseItemExporter):
         # Set up the collection
         database = connection[self.config['database']]
         self.collection = database[self.config['collection']]
-        log.msg('Connected to MongoDB {0}, using "{1}/{2}"'.format(
+        log.msg(u'Connected to MongoDB {0}, using "{1}/{2}"'.format(
             self.config['uri'],
             self.config['database'],
             self.config['collection']))


### PR DESCRIPTION
If password has special characters in the password, the log message will break because of config['uri']. This is a fix. Issue #26