### PR TITLE
Allow per-spider configuration

### DIFF
--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -73,7 +73,7 @@ class MongoDBPipeline(BaseItemExporter):
         self.settings = spider.settings
 
         # Versions prior to 0.25
-        if not getattr(spider, 'update_settings', False):
+        if not hasattr(spider, 'update_settings') and hasattr(spider, 'custom_settings'):
             self.settings.setdict(spider.custom_settings or {}, priority='project')
 
     def open_spider(self, spider):


### PR DESCRIPTION
Scrapy version 0.25 (master) has per spider configuration - see [`custom_settings`](https://github.com/scrapy/scrapy/search?utf8=%E2%9C%93&q=update_settings)

This PR is consonant with that but also supports older versions by using the same property in the spider to update MongoDBPipeline settings.

Fixes #17