### PR TITLE
Fix memory leak in item buffer

### DIFF
--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -211,7 +211,10 @@ class MongoDBPipeline(BaseItemExporter):
 
             if self.current_item == self.config['buffer']:
                 self.current_item = 0
-                return self.insert_item(self.item_buffer, spider)
+                try:
+                    return self.insert_item(self.item_buffer, spider)
+                finally:
+                    self.item_buffer = []
 
             else:
                 return item


### PR DESCRIPTION
Item buffer was not being cleaned up after database writes, which became apparent with a large buffer size and memory usage growing rapidly.