### PR TITLE
Feature remove none

### DIFF
--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -201,6 +201,8 @@ class MongoDBPipeline(BaseItemExporter):
         """
         item = dict(self._get_serialized_fields(item))
 
+        item = dict((k, v) for k, v in item.iteritems() if v is not None and v != "")
+
         if self.config['buffer']:
             self.current_item += 1
 

--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -211,7 +211,10 @@ class MongoDBPipeline(BaseItemExporter):
 
             if self.current_item == self.config['buffer']:
                 self.current_item = 0
-                return self.insert_item(self.item_buffer, spider)
+                try:
+                    return self.insert_item(self.item_buffer, spider)
+                finally:
+                    self.item_buffer = []
 
             else:
                 return item


### PR DESCRIPTION
Items in scrapy have fixed keys, but if some of the keys do not hold a value, a null reference is still inserted in mongo. I think that items exported to mongo should be filtered for None or empty string values. 
This pull request comes with fixes from @dvukolov
