### PR TITLE
Allow ssl connections with a self signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ MONGODB_SEPARATE_COLLECTIONS = True
 | `MONGODB_REPLICA_SET` | None | Yes, for replica sets | Set this if you want to enable replica set support. The option should be given the name of the replica sets you want to connect to. `MONGODB_URI` should point at your config servers. |
 | `MONGODB_REPLICA_SET_W` | 0 | No | Best described in the [pymongo docs][2]. Write operations will block until they have been replicated to the specified number or tagged set of servers. `w=<int>` always includes the replica set primary (e.g. `w=3` means write to the primary and wait until replicated to two secondaries). Passing `w=0` disables write acknowledgement and all other write concern options.
 | `MONGODB_STOP_ON_DUPLICATE` | 0 | No | Set this to a value greater than 0 to close the spider when that number of duplicated insertions in MongoDB are detected. If set to 0, this option has no effect. |
+| `MONGODB_VERIFY_SSL` | None | No | Specifies whether to validate certificate for connection. None, ssl.CERT_NONE, ssl.CERT_REQUIRED, or ssl.CERT_OPTIONAL |
+
+
 
 [1]: http://docs.mongodb.org/manual/reference/connection-string
 [2]: http://api.mongodb.org/python/current/api/pymongo/mongo_replica_set_client.html#pymongo.mongo_replica_set_client.MongoReplicaSetClient

--- a/scrapy_mongodb.py
+++ b/scrapy_mongodb.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-
+import ssl
 import six
 from pymongo import errors
 from pymongo.mongo_client import MongoClient
@@ -38,6 +38,7 @@ class MongoDBPipeline(BaseItemExporter):
         'buffer': None,
         'append_timestamp': False,
         'stop_on_duplicate': 0,
+        'verify_ssl': None
     }
 
     # Item buffer
@@ -78,7 +79,8 @@ class MongoDBPipeline(BaseItemExporter):
             connection = MongoClient(
                 self.config['uri'],
                 fsync=self.config['fsync'],
-                read_preference=ReadPreference.PRIMARY)
+                read_preference=ReadPreference.PRIMARY,
+                ssl_cert_reqs=self.config['verify_ssl'])
 
         # Set up the database
         self.database = connection[self.config['database']]
@@ -145,7 +147,8 @@ class MongoDBPipeline(BaseItemExporter):
             ('unique_key', 'MONGODB_UNIQUE_KEY'),
             ('buffer', 'MONGODB_BUFFER_DATA'),
             ('append_timestamp', 'MONGODB_ADD_TIMESTAMP'),
-            ('stop_on_duplicate', 'MONGODB_STOP_ON_DUPLICATE')
+            ('stop_on_duplicate', 'MONGODB_STOP_ON_DUPLICATE'),
+            ('verify_ssl', 'MONGODB_VERIFY_SSL')
         ]
 
         for key, setting in options:


### PR DESCRIPTION
Add an option to supply configuration for `ssl_cert_reqs` parameter in Mongo DB client.
This way, we can disable SSL verification for self signed certificates. 